### PR TITLE
Added github workflows for release and deploy (#10)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     steps:
+
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: 3. Deploy to Azure
+
+on:
+  release:
+    types: [published]
+
+  # enables manual triggers
+  workflow_dispatch:
+    inputs:
+      release_id:
+        description: 'Release tag id to be deployed'
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy to Azure
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Get release version
+      id: get_version
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        else
+          echo "version=${{ inputs.release_id }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Build Docker Image
+      run: |
+        docker build --platform linux/amd64 -t cliedl/electify:${{ steps.get_version.outputs.version }} .
+
+    - name: Push Docker Image
+      run: |
+        docker push cliedl/electify:${{ steps.get_version.outputs.version }}
+        
+    - name: Log in to Azure
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Build and deploy Container App
+      uses: azure/container-apps-deploy-action@v1
+      with:
+        acrName: myregistry
+        containerAppName: my-container-app
+        resourceGroup: my-rg
+        imageToDeploy: cliedl/electify:${{ steps.get_version.outputs.version }}

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'bundestag-2025'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: 2. Draft Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+  # enables manual triggers
+  workflow_dispatch:
+
+jobs:
+  draft_release:
+    name: Create Draft Release
+    permissions:
+      contents: write
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.bump_version.outputs.new_version }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Fetch all tags
+        run: |
+          git fetch --tags
+          echo "GH_TOKEN=${{ github.token }}" >> $GITHUB_ENV
+
+      - name: Determine Next Version
+        id: bump_version
+        run: |
+          LATEST_TAG=$(git tag --sort=-v:refname | head -n 1)
+          if [[ -z "$LATEST_TAG" ]]; then
+            NEW_VERSION="0.0.1"
+          else
+            IFS='.' read -r -a PARTS <<< "$LATEST_TAG"
+            NEW_VERSION="${PARTS[0]}.${PARTS[1]}.$((PARTS[2] + 1))"
+          fi
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ env.NEW_VERSION }}
+          name: Release ${{ env.NEW_VERSION }}
+          body: "Automated draft release for version ${{ env.NEW_VERSION }}"
+          draft: true
+          prerelease: false


### PR DESCRIPTION
# Added github actions for release and deploy

## release:
* triggered by push or merged PR on main
* Creates a new release draft with incremented version number
## deploy:
* triggered by release
* Builds image
* Pushes to Dockerhub
* Creates new revision on azure (does not redirect traffic yet)
 
 
# Workflow for deployment:
1) Push or merge PR on main
2) Go to releases and click publish release (add some description for the release)
3) Go to azure portal. Check if deployment was successful (there is a deployment for each revision) and then redirect traffic
4) Delete the old revision (optional)